### PR TITLE
Add option to toggle thank you redirect outside the webview

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ Constructor - `CustomParam(CharSequence name, CharSequence value)`
 |`SsSurvey`|`addCustomParams(CustomParam[] customParams)`: add custom params by passing `SsSurvey.CustomParam` object array.
 |`SsSurvey`|`addCustomParam(CharSequence name, CharSequence value)`: add custom param by passing name & value.
 |`SsSurvey`|`setSurveyType(@SurveyType int surveyType)`: set survey type to CLASSIC/CHAT/NPS
+|`SsSurvey`|`setThankYouRedirect(boolean thankyouRedirect)`: toggle redirect to thank you page outside the webview
 
 
 ### SurveySparrow

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurvey.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurvey.java
@@ -11,6 +11,7 @@ public final class SsSurvey implements Serializable {
     private String surveyToken;
     private String customVariableString = "?";
     private int surveyType = SurveySparrow.CLASSIC;
+    private boolean isThankYouRedirect = true;
 
     /**
      * Custom param class
@@ -61,6 +62,10 @@ public final class SsSurvey implements Serializable {
 
     String getSurveyToken() {
         return surveyToken;
+    }
+
+    boolean getThankYouRedirect() {
+        return isThankYouRedirect;
     }
 
     /**
@@ -122,5 +127,17 @@ public final class SsSurvey implements Serializable {
 
     private String generateBaseUrl(CharSequence domain, CharSequence surveyToken) {
         return "https://" + domain + "/" + (surveyType == SurveySparrow.NPS ? 'n' : 's') + "/android/" + surveyToken;
+    }
+
+    /**
+     * Whether to redirect to thank you page outside the webview
+     *
+     * @param thankYouRedirect Boolean to toggle the redirect behaviour
+     * @return Returns the same SsSurvey object, for chaining
+     * multiple calls into a single statement.
+     */
+    public SsSurvey setThankYouRedirect(boolean thankYouRedirect) {
+        isThankYouRedirect = thankYouRedirect;
+        return this;
     }
 }

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyFragment.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyFragment.java
@@ -69,11 +69,12 @@ public final class SsSurveyFragment extends Fragment {
         ssWebView.setWebViewClient(new WebViewClient() {
             @Override
             public boolean shouldOverrideUrlLoading(WebView view, String url) {
-                if (url.contains(SurveySparrow.SS_THANK_YOU_BASE_URL)) {
+                if (url.contains(SurveySparrow.SS_THANK_YOU_BASE_URL) || survey.getThankYouRedirect() == false) {
                     return super.shouldOverrideUrlLoading(view, url);
+                } else {
+                    view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
+                    return true;
                 }
-                view.getContext().startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
-                return true;
             }
         });
 


### PR DESCRIPTION
- Added `setThankyouRedirect` method to `SsSurvey` class to provide the option to toggle thank you page redirect outside the web-view after the survey is submitted.
- Updated README.md with the necessary instructions to use the `setThankyouRedirect` method.
