### PR TITLE
Fix issue - Unable to instantiate fragment - public constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Add the following line to your **app modules** `build.gradle` file inside `dependencies`
 ```gradle
-implementation 'com.surveysparrow:ss-android-sdk:0.3.0'
+implementation 'com.surveysparrow:ss-android-sdk:0.4.0'
 ```
 
 The SDK need Internet access to fetch survey & submit answers. Add the following permissions to `AndroidManifest.xml` file
@@ -78,9 +78,18 @@ SsSurvey survey = new SsSurvey("your-company-domain", "sdk-token");
 ```
 
 #### Embed survey in your Activity
+**For versions below 0.4.0**
 ```java
 SsSurveyFragment surveyFragment = new SsSurveyFragment(survey);
+```
 
+**For other versions**
+```java
+SsSurveyFragment surveyFragment = new SsSurveyFragment();
+surveyFragment.setSurvey(survey);
+```
+#### Start the fragment transaction
+```java
 FragmentManager fragmentManager = this.getSupportFragmentManager();
 FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
 fragmentTransaction.add(R.id.surveyContainer, surveyFragment);

--- a/examples/movie_review_kotlin/app/build.gradle
+++ b/examples/movie_review_kotlin/app/build.gradle
@@ -34,5 +34,5 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 
     // SurveySparrow SDK
-    implementation 'com.surveysparrow:ss-android-sdk:0.2.0'
+    implementation 'com.surveysparrow:ss-android-sdk:0.4.0'
 }

--- a/examples/simple-java/app/build.gradle
+++ b/examples/simple-java/app/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     //survey-sparrow-android-sdk
-    implementation 'com.surveysparrow:ss-android-sdk:0.2.0'
+    implementation 'com.surveysparrow:ss-android-sdk:0.4.0'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/examples/simple-java/app/src/main/java/com/surveysparrow/sdk/example/simple_java/MainActivity.java
+++ b/examples/simple-java/app/src/main/java/com/surveysparrow/sdk/example/simple_java/MainActivity.java
@@ -67,7 +67,8 @@ public class MainActivity extends AppCompatActivity implements OnSsResponseEvent
     }
 
     public void showSurveyFragment(View v) {
-        SsSurveyFragment surveyFragment = new SsSurveyFragment(survey);
+        SsSurveyFragment surveyFragment = new SsSurveyFragment();
+        surveyFragment.setSurvey(survey);
 
         // Add the SsSurveyFragment to the Activity.
         FragmentManager fragmentManager = this.getSupportFragmentManager();

--- a/survey-sparrow-android-sdk/build.gradle
+++ b/survey-sparrow-android-sdk/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'com.android.library'
 
-def stringVersionName = '0.3.0'
+def stringVersionName = '0.4.0'
 
 android {
     compileSdkVersion 29

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
@@ -21,7 +21,7 @@ public final class SsSurveyActivity extends AppCompatActivity implements OnSsRes
     private CharSequence appbarTitle;
     private boolean enableButton;
     private long waitTime;
-    public static final String SS_RUNTIME_EXCEPTION_LOG = "SS_RUNTIME_EXCEPTION_LOG";
+    public static final String SS_RUNTIME_EX_LOG = "SS_RUNTIME_EXCEPTION_LOG";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -51,7 +51,7 @@ public final class SsSurveyActivity extends AppCompatActivity implements OnSsRes
             fragmentTransaction.add(R.id.surveyContainer, surveyFragment);
             fragmentTransaction.commit();
         } catch (Exception e) {
-            Log.e(SS_RUNTIME_EXCEPTION_LOG, e.getStackTrace().toString());
+            Log.e(SS_RUNTIME_EX_LOG, e.getStackTrace().toString());
         }
     }
 

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.view.MenuItem;
+import android.util.Log;
 
 import org.json.JSONObject;
 

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
@@ -21,7 +21,7 @@ public final class SsSurveyActivity extends AppCompatActivity implements OnSsRes
     private CharSequence appbarTitle;
     private boolean enableButton;
     private long waitTime;
-    public static final String SS_RUNTIME_EX_LOG = "SS_RUNTIME_EXCEPTION_LOG";
+    public static final String SS_RT_EXCEPTION_LOG = "SS_RT_EXCEPTION_LOG";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -51,7 +51,7 @@ public final class SsSurveyActivity extends AppCompatActivity implements OnSsRes
             fragmentTransaction.add(R.id.surveyContainer, surveyFragment);
             fragmentTransaction.commit();
         } catch (Exception e) {
-            Log.e(SS_RUNTIME_EX_LOG, e.getStackTrace().toString());
+            Log.e(SS_RT_EXCEPTION_LOG, e.getStackTrace().toString());
         }
     }
 

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyActivity.java
@@ -20,32 +20,38 @@ public final class SsSurveyActivity extends AppCompatActivity implements OnSsRes
     private CharSequence appbarTitle;
     private boolean enableButton;
     private long waitTime;
+    public static final String SS_RUNTIME_EXCEPTION_LOG = "SS_RUNTIME_EXCEPTION_LOG";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-
-        Intent intent = getIntent();
-        activityTheme = intent.getIntExtra(SurveySparrow.SS_ACTIVITY_THEME, R.style.SurveyTheme);
-        appbarTitle = intent.getStringExtra(SurveySparrow.SS_APPBAR_TITLE);
-        enableButton = intent.getBooleanExtra(SurveySparrow.SS_BACK_BUTTON, true);
-        waitTime = intent.getLongExtra(SurveySparrow.SS_WAIT_TIME, SurveySparrow.SS_DEFAULT_WAIT_TIME);
-        survey = (SsSurvey) intent.getSerializableExtra(SurveySparrow.SS_SURVEY);
-
-        setTheme(activityTheme);
-        setContentView(R.layout.activity_ss_survey);
-        ActionBar actionBar = getSupportActionBar();
-        if (actionBar != null) {
-            actionBar.setTitle(appbarTitle);
-            actionBar.setDisplayHomeAsUpEnabled(enableButton);
+        try {
+            super.onCreate(savedInstanceState);
+    
+            Intent intent = getIntent();
+            activityTheme = intent.getIntExtra(SurveySparrow.SS_ACTIVITY_THEME, R.style.SurveyTheme);
+            appbarTitle = intent.getStringExtra(SurveySparrow.SS_APPBAR_TITLE);
+            enableButton = intent.getBooleanExtra(SurveySparrow.SS_BACK_BUTTON, true);
+            waitTime = intent.getLongExtra(SurveySparrow.SS_WAIT_TIME, SurveySparrow.SS_DEFAULT_WAIT_TIME);
+            survey = (SsSurvey) intent.getSerializableExtra(SurveySparrow.SS_SURVEY);
+    
+            setTheme(activityTheme);
+            setContentView(R.layout.activity_ss_survey);
+            ActionBar actionBar = getSupportActionBar();
+            if (actionBar != null) {
+                actionBar.setTitle(appbarTitle);
+                actionBar.setDisplayHomeAsUpEnabled(enableButton);
+            }
+    
+            FragmentManager fragmentManager = getSupportFragmentManager();
+            FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
+    
+            SsSurveyFragment surveyFragment = new SsSurveyFragment();
+            surveyFragment.setSurvey(survey);
+            fragmentTransaction.add(R.id.surveyContainer, surveyFragment);
+            fragmentTransaction.commit();
+        } catch (Exception e) {
+            Log.e(SS_RUNTIME_EXCEPTION_LOG, e.getStackTrace().toString());
         }
-
-        FragmentManager fragmentManager = getSupportFragmentManager();
-        FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
-
-        SsSurveyFragment surveyFragment = new SsSurveyFragment(survey);
-        fragmentTransaction.add(R.id.surveyContainer, surveyFragment);
-        fragmentTransaction.commit();
     }
 
     @Override

--- a/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyFragment.java
+++ b/survey-sparrow-android-sdk/src/main/java/com/surveysparrow/ss_android_sdk/SsSurveyFragment.java
@@ -38,12 +38,22 @@ public final class SsSurveyFragment extends Fragment {
     private OnSsResponseEventListener onSsResponseEventListener;
 
     /**
-     * Create SsSurveyFragment.
-     * @param survey SsSurvey object.
-     * @see SsSurvey
+     * Create SsSurveyFragment public constructor.
      */
-    public SsSurveyFragment(SsSurvey survey) {
+    public SsSurveyFragment() {
+        //  public, no-arg constructor 
+    }
+
+    /**
+     * Set the survey object.
+     * 
+     * @param survey SsSurvey object.
+     * @return Returns the same SsSurveyFragment object, for chaining
+     * multiple calls into a single statement.
+     */
+    public SsSurveyFragment setSurvey(SsSurvey survey) {
         this.survey = survey;
+        return this;
     }
 
     @Override


### PR DESCRIPTION
This PR includes 

- Fix for the below issue
  ```
  androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment
  com.surveysparrow.ss_android_sdk.SsSurveyFragment: could not find Fragment constructor
  ```
- Updated Readme and SDK version in the examples to the latest.